### PR TITLE
Bump component version to 5.0.0-SNAPSHOT

### DIFF
--- a/modules/siddhi-launcher/pom.xml
+++ b/modules/siddhi-launcher/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.siddhi.sdk</groupId>
         <artifactId>siddhi-sdk-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>siddhi-launcher</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>io.siddhi.sdk</groupId>
     <artifactId>siddhi-sdk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
     <name>WSO2 Siddhi SDK</name>
 
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
This PR bumps the Siddhi-SDK version to 5.0.0-SNAPSHOT to be compliance with underlying Siddhi version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes